### PR TITLE
Introduce delay before reading CPU MHz

### DIFF
--- a/pve-manager-status.sh
+++ b/pve-manager-status.sh
@@ -217,7 +217,7 @@ cat > "$tmpf1" << 'EOF'
         $res->{cpupower} = $cpumodes . $cpupowers;
 
         my $cpufreqs = `lscpu | grep MHz`;
-        my $threadfreqs = `cat /proc/cpuinfo | grep -i "cpu MHz"`;
+        my $threadfreqs = `sleep 0.2; cat /proc/cpuinfo | grep -i "cpu MHz"`;
         $res->{cpufreq} = $cpufreqs . $threadfreqs;
 
         $res->{sensors} = `sudo sensors`;


### PR DESCRIPTION
Add a sleep delay before fetching CPU frequencies. 这是能找到的最好的PVE温度状态显示修改脚本了，但有一个问题就是页面后台刷新本身的资源占用导致显示的CPU线程频率偏高很多，经过多次尝试，在获取CPU频率之前 sleep 0.2秒，使当前进程冷却一小段时间再获取CPU频率即可相对准确。希望作者采纳 :)